### PR TITLE
Return BeautifulSoup object, not text string, on success

### DIFF
--- a/ksmyvoteinfo/client.py
+++ b/ksmyvoteinfo/client.py
@@ -4,7 +4,7 @@ from robobrowser import RoboBrowser
 
 class KsMyVoteInfo(object):
 
-  version = '0.2'
+  version = '0.3'
 
   COUNTY_CODES = {
     "Allen": "308700",
@@ -130,7 +130,7 @@ class KsMyVoteInfo(object):
     browser.submit_form(form)
 
     if browser.select('#registrant'):
-      return browser.select('#registrant')[0].text
+      return browser.select('#registrant')[0]
     else:
       return False
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='ksmyvoteinfo',
-      version='0.2',
+      version='0.3',
       description='Query the KS SOS site for voter registration',
       url='http://github.com/BlueprintKansas/ksmyvoteinfo-py',
       author='Peter Karman',

--- a/tests/test_ksmyvoteinfo.py
+++ b/tests/test_ksmyvoteinfo.py
@@ -14,5 +14,5 @@ def test_lookup_pass():
   kmvi = KsMyVoteInfo()
   r = kmvi.lookup(first_name='Kris', last_name='Kobach', dob='1966-03-26', county='Douglas')
   regex = re.compile(r'Republican')
-  matches = regex.search(r)
+  matches = regex.search(r.text)
   assert matches is not None


### PR DESCRIPTION
Instead of forcing the HTML object to extract text (with the ugly whitespace), return the object instead so that the caller can decide what to do with it.